### PR TITLE
Load plugins before validating config

### DIFF
--- a/tests/etc/zoidberg.yaml
+++ b/tests/etc/zoidberg.yaml
@@ -19,5 +19,10 @@
       key_filename: some/other/key
       username: thirdparty_user
       project-pattern: .*
-      events: []
+      events:
+      - type: ref-updated
+        action: thirdpartyactions.AnExcellentAction
+        branch-pattern: ^master$
+        target: master
+
 - plugins: [tests.thirdpartyactions, tests.moreactions]

--- a/tests/test_zoidberg.py
+++ b/tests/test_zoidberg.py
@@ -15,7 +15,7 @@ class CountdownToFalse(object):
     def __init__(self, default):
         self.default = default
         self.data = WeakKeyDictionary()
-        
+
     def __get__(self, instance, owner):
         countdown = self.data.get(instance, self.default)
         if countdown > 0:
@@ -23,7 +23,7 @@ class CountdownToFalse(object):
             self.data[instance] = countdown
             return True
         return False
-    
+
     def __set__(self, instance, value):
         if not value:
             # make sure we're False
@@ -266,4 +266,15 @@ class ZoidbergTestCase(testtools.TestCase):
         self.assertTrue(issubclass(action, actions.Action))
         action = actions.ActionRegistry.get(
             'moreactions.JustSomeActionOrOther')
+        self.assertTrue(issubclass(action, actions.Action))
+
+    def test_configuration_with_plugin_action(self):
+        """
+        Check that a third party plugin is properly loaded from configuration.
+        """
+        config = self.zoidberg.config
+        gerrit_config = config.gerrits.get('thirdparty')
+        event_type = gerrit_config['events']['ref-updated']
+        action = actions.ActionRegistry.get(
+            'thirdpartyactions.AnExcellentAction')
         self.assertTrue(issubclass(action, actions.Action))

--- a/tests/test_zoidberg.py
+++ b/tests/test_zoidberg.py
@@ -195,7 +195,7 @@ class ZoidbergTestCase(testtools.TestCase):
         mock_client.activate_ssh.assert_called_once_with(
             gerrit_cfg['host'], gerrit_cfg['username'],
             gerrit_cfg['key_filename'], 29418)
-        mock_client.start_event_stream.assert_called_once()
+        self.assertEqual(1, mock_client.start_event_stream.call_count)
         mock_queue_startup_tasks.assert_called_once_with(gerrit_cfg)
 
     @patch.object(TestableZoidberg ,'queue_startup_tasks')

--- a/zoidberg/zoidberg.py
+++ b/zoidberg/zoidberg.py
@@ -35,9 +35,6 @@ class Zoidberg(object):
     def __init__(self, config_file):
         self.config = None
         self.load_config(config_file, raise_exception=True)
-        for module_name in self.config.plugins:
-            action_module = '%s.actions' % module_name
-            importlib.import_module(action_module)
         self.startup_tasks = Queue()
         self.running = True
 
@@ -124,6 +121,9 @@ class Zoidberg(object):
         try:
             config_from_yaml = yaml.load(open(config_file, 'r'))
             config = configuration.Configuration(config_from_yaml)
+            for module_name in config.plugins:
+                action_module = '%s.actions' % module_name
+                importlib.import_module(action_module)
             self.validate_config(config)
             self.config_filename = config_file
             self.config_mtime = os.stat(config_file).st_mtime


### PR DESCRIPTION
Config validation for events will look for valid actions.  The problem
arises when the action is provided by a plugin.  If the plugin is not
loaded prior to validation, the custom action cannot be properly added
to the ActionRegistry, and the config validation will fail.
